### PR TITLE
CR-5034 switch SNS topic to use customer managed key

### DIFF
--- a/templates/email-sns-stack.json.tpl
+++ b/templates/email-sns-stack.json.tpl
@@ -6,7 +6,7 @@
       "Type" : "AWS::SNS::Topic",
       "Properties" : {
         "DisplayName" : "${display_name}",
-        "KmsMasterKeyId" : "alias/aws/sns",
+        "KmsMasterKeyId" : "alias/cw-to-sns-key",
         "Subscription": [
           {
            "Endpoint" : "${email_address}",


### PR DESCRIPTION
The key itself is managed in the shared-infrastructure repo.